### PR TITLE
ADDS, MUL, and POW alternatives

### DIFF
--- a/notebooks/lambda/Y+Combinator.ipynb
+++ b/notebooks/lambda/Y+Combinator.ipynb
@@ -72,9 +72,9 @@
     "#Arithmetic\n",
     "#Count\n",
     "S = lambda n: lambda f: lambda x: f(n(f)(x))\n",
-    "ADDS = lambda m: lambda n: lambda f: lambda x: m(S)(n)(f)(x)\n",
-    "MUL = lambda m: lambda n: lambda f: lambda x: m(n(f))(x)\n",
-    "POW = lambda m: lambda n: lambda f: lambda x: S(n)(m(f))(x)"
+    "ADDS = lambda m: lambda n: m(S)(n)\n",
+    "MUL = lambda m: lambda n: m(ADD(n))(N0)\n",
+    "POW = lambda e: lambda b: e(MUL(b))(N1)"
    ]
   },
   {


### PR DESCRIPTION
Proposed three alternative definitions to mathematical lambdas that may provide pedagogical clarity
• Applied 𝜂-conversion twice to ADDS to reduce argument count from four to two (Now should read as "start from n", consider the action "apply the successor function", repeat this action "m times").
• Proposed an alternative definition to MUL based on the above (it should be read as From ZERO, consider the action "ADD n", do this action "m times".
• Similarly for POW. (Start with ONE, consider the action "multiply by n", do this "m times"). Also proposed changing the bound variable names to clarify which is the base and which is the exponent).